### PR TITLE
Fix and Test for Issue 3

### DIFF
--- a/SharpBrake/AirbrakeNoticeBuilder.cs
+++ b/SharpBrake/AirbrakeNoticeBuilder.cs
@@ -255,11 +255,8 @@ namespace SharpBrake
 
                 string file = frame.GetFileName();
 
-                /*if (String.IsNullOrEmpty(file))
-                    file = method.ReflectedType != null ? method.ReflectedType.FullName : "(unknown)";*/
-
-                if (String.IsNullOrEmpty(file))
-                    file = method.ReflectedType.FullName;
+				if (String.IsNullOrEmpty(file))
+					file = method.ReflectedType != null ? method.ReflectedType.FullName : "(unknown)";
 
                 AirbrakeTraceLine line = new AirbrakeTraceLine(file, lineNumber)
                 {

--- a/Tests/NoticeComponentsCreation.cs
+++ b/Tests/NoticeComponentsCreation.cs
@@ -1,6 +1,6 @@
 using System;
 using System.IO;
-
+using System.Linq.Expressions;
 using NUnit.Framework;
 
 using SharpBrake.Serialization;
@@ -147,27 +147,21 @@ namespace SharpBrake.Tests
 
 
         [Test]
-        [Ignore("Pending https://github.com/asbjornu/SharpBrake/pull/3")]
         public void StackTrace_contains_lambda_expression()
         {
             Exception exception = null;
 
-            try
+			try
             {
-                Action action = () =>
-                {
-                    Action inner = () => { throw new InvalidOperationException("test error"); };
-                    inner.Invoke();
-                };
+ 				Expression<Func<int>> inner = () => ((string)null).Length;
 
-                action.Invoke();
+            	inner.Compile()();
             }
             catch (Exception testException)
             {
                 exception = testException;
             }
 
-            // TODO: Figure out how to get this to fail.
             this.builder.ErrorFromException(exception);
         }
     }


### PR DESCRIPTION
Added test case showing how AirbrakeNoticeBuilder breaks when a compiled lambda expression throws an exception, then fixed the bug.  Fixes Issue 3 plus includes a test to demonstrate the need for the fix. 
