### PR TITLE
Updated Trace building to include full stack trace

### DIFF
--- a/src/SharpBrake.2010.sln
+++ b/src/SharpBrake.2010.sln
@@ -1,9 +1,16 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{D5D6C540-2F8B-4766-A9F6-75715A8E6F26}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{B72B5556-3CA1-400F-9205-B28CB5B0E6D5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{5D42745D-106E-4A67-808C-B5A2A75F82E4}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\NuGet.Config = .nuget\NuGet.Config
+		.nuget\NuGet.exe = .nuget\NuGet.exe
+		.nuget\NuGet.targets = .nuget\NuGet.targets
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpBrake.2010", "app\SharpBrake\SharpBrake.2010.csproj", "{EE7CE02E-3CA9-4D01-8D57-E98911466B44}"
 EndProject
@@ -12,13 +19,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebFormsApp.2010", "tests\WebFormsApp\WebFormsApp.2010.csproj", "{91EFAC45-916F-46D5-B96D-5C7F186DE3CE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MvcApp", "tests\MvcApp\MvcApp.csproj", "{FD358339-DAF6-4276-A43C-32BAB831562D}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{5D42745D-106E-4A67-808C-B5A2A75F82E4}"
-	ProjectSection(SolutionItems) = preProject
-		.nuget\NuGet.Config = .nuget\NuGet.Config
-		.nuget\NuGet.exe = .nuget\NuGet.exe
-		.nuget\NuGet.targets = .nuget\NuGet.targets
-	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/app/SharpBrake/AirbrakeClient.cs
+++ b/src/app/SharpBrake/AirbrakeClient.cs
@@ -24,7 +24,7 @@ namespace SharpBrake
         /// Initializes a new instance of the <see cref="AirbrakeClient"/> class.
         /// </summary>
         public AirbrakeClient()
-            : this(new AirbrakeConfiguration())
+            : this(new AirbrakeConfiguration(), new BacktraceBuilder(LogManager.GetLogger<BacktraceBuilder>()))
         {
         }
 
@@ -33,13 +33,18 @@ namespace SharpBrake
         /// Initializes a new instance of the <see cref="AirbrakeClient"/> class.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
-        public AirbrakeClient(AirbrakeConfiguration configuration)
+        /// <param name="backtraceBuilder"> </param>
+        public AirbrakeClient(AirbrakeConfiguration configuration, IBuilder<Exception, Backtrace> backtraceBuilder = null)
         {
             if (configuration == null)
                 throw new ArgumentNullException("configuration");
 
             this.configuration = configuration;
-            this.builder = new AirbrakeNoticeBuilder(configuration);
+
+            if (backtraceBuilder == null)
+                backtraceBuilder = new BacktraceBuilder(LogManager.GetLogger<BacktraceBuilder>());
+            this.builder = new AirbrakeNoticeBuilder(configuration,backtraceBuilder);
+
             this.log = LogManager.GetLogger(GetType());
         }
 

--- a/src/app/SharpBrake/AirbrakeNoticeBuilder.cs
+++ b/src/app/SharpBrake/AirbrakeNoticeBuilder.cs
@@ -19,6 +19,7 @@ namespace SharpBrake
     public class AirbrakeNoticeBuilder
     {
         private readonly AirbrakeConfiguration configuration;
+        private readonly IBuilder<Exception, Backtrace> _backtraceBuilder;
         private readonly ILog log;
         private AirbrakeServerEnvironment environment;
         private AirbrakeNotifier notifier;
@@ -28,7 +29,7 @@ namespace SharpBrake
         /// Initializes a new instance of the <see cref="AirbrakeNoticeBuilder"/> class.
         /// </summary>
         public AirbrakeNoticeBuilder()
-            : this(new AirbrakeConfiguration())
+            : this(new AirbrakeConfiguration(), new BacktraceBuilder(LogManager.GetLogger<BacktraceBuilder>()))
         {
         }
 
@@ -37,12 +38,14 @@ namespace SharpBrake
         /// Initializes a new instance of the <see cref="AirbrakeNoticeBuilder"/> class.
         /// </summary>
         /// <param name="configuration">The configuration.</param>
-        public AirbrakeNoticeBuilder(AirbrakeConfiguration configuration)
+        /// <param name="backtraceBuilder">Builder used for building backtrace data </param>
+        public AirbrakeNoticeBuilder(AirbrakeConfiguration configuration, IBuilder<Exception, Backtrace> backtraceBuilder)
         {
             if (configuration == null)
                 throw new ArgumentNullException("configuration");
 
             this.configuration = configuration;
+            _backtraceBuilder = backtraceBuilder;
             this.log = LogManager.GetLogger(GetType());
         }
 
@@ -102,15 +105,13 @@ namespace SharpBrake
 
             this.log.Debug(f => f("{0}.Notice({1})", GetType(), exception.GetType()), exception);
 
-            MethodBase catchingMethod;
-            var backtrace = BuildBacktrace(exception, out catchingMethod);
+            var backtrace = _backtraceBuilder.Build(exception);
 
             var error = Activator.CreateInstance<AirbrakeError>();
-
-            error.CatchingMethod = catchingMethod;
+            error.CatchingMethod = backtrace.CatchingMethod;
             error.Class = exception.GetType().FullName;
-            error.Message = exception.GetType().Name + ": " + exception.Message;
-            error.Backtrace = backtrace;
+            error.Message = backtrace.Message;
+            error.Backtrace = backtrace.Trace.ToArray();
 
             return error;
         }
@@ -234,70 +235,6 @@ namespace SharpBrake
             request.Session = session.Any() ? session.ToArray() : null;
             notice.Request = request;
         }
-
-
-        private AirbrakeTraceLine[] BuildBacktrace(Exception exception, out MethodBase catchingMethod)
-        {
-            Assembly assembly = Assembly.GetExecutingAssembly();
-
-            if (assembly.EntryPoint == null)
-                assembly = Assembly.GetCallingAssembly();
-
-            if (assembly.EntryPoint == null)
-                assembly = Assembly.GetEntryAssembly();
-
-            catchingMethod = assembly == null
-                                 ? null
-                                 : assembly.EntryPoint;
-
-            List<AirbrakeTraceLine> lines = new List<AirbrakeTraceLine>();
-            var stackTrace = new StackTrace(exception);
-            StackFrame[] frames = stackTrace.GetFrames();
-
-            if (frames == null || frames.Length == 0)
-            {
-                // Airbrake requires that at least one line is present in the XML.
-                AirbrakeTraceLine line = new AirbrakeTraceLine("none", 0);
-                lines.Add(line);
-                return lines.ToArray();
-            }
-
-            foreach (StackFrame frame in frames)
-            {
-                MethodBase method = frame.GetMethod();
-
-                catchingMethod = method;
-
-                int lineNumber = frame.GetFileLineNumber();
-
-                if (lineNumber == 0)
-                {
-                    this.log.Debug(f => f("No line number found in {0}, using IL offset instead.", method));
-                    lineNumber = frame.GetILOffset();
-                }
-
-                string file = frame.GetFileName();
-
-                if (String.IsNullOrEmpty(file))
-                {
-                    // ReSharper disable ConditionIsAlwaysTrueOrFalse
-                    file = method.ReflectedType != null
-                               ? method.ReflectedType.FullName
-                               : "(unknown)";
-                    // ReSharper restore ConditionIsAlwaysTrueOrFalse
-                }
-
-                AirbrakeTraceLine line = new AirbrakeTraceLine(file, lineNumber)
-                {
-                    Method = method.Name
-                };
-
-                lines.Add(line);
-            }
-
-            return lines.ToArray();
-        }
-
 
         private IEnumerable<AirbrakeVar> BuildVars(HttpCookieCollection cookies)
         {

--- a/src/app/SharpBrake/Backtrace.cs
+++ b/src/app/SharpBrake/Backtrace.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using SharpBrake.Serialization;
+
+namespace SharpBrake
+{
+    /// <summary>
+    /// Represents information about an error
+    /// </summary>
+    public class Backtrace
+    {
+        /// <summary>
+        /// Message component
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Stack Trace of the exception
+        /// </summary>
+        public List<AirbrakeTraceLine> Trace { get; set; }
+
+        /// <summary>
+        /// Method where the exception occured at
+        /// </summary>
+        public MethodBase CatchingMethod { get; set; }
+    }
+}

--- a/src/app/SharpBrake/BacktraceBuilder.cs
+++ b/src/app/SharpBrake/BacktraceBuilder.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Common.Logging;
+using SharpBrake.Serialization;
+namespace SharpBrake
+{
+    /// <summary>
+    /// Builds a Backtrace from an exception
+    /// </summary>
+    public class BacktraceBuilder : IBuilder<Exception,Backtrace>
+    {
+        private readonly ILog _log;
+
+        /// <summary>
+        /// Constructor with dependencies
+        /// </summary>
+        /// <param name="log"></param>
+        public BacktraceBuilder(ILog log)
+        {
+            _log = log;
+        }
+
+        public Backtrace Build(Exception exception)
+        {
+            var messageBuilder = new StringBuilder();
+            var stackFrames= new List<StackFrame>();
+
+            // Get all the exceptions that caused this to bubble up
+            var exceptionStack = GetExceptionStack(exception);
+            
+            foreach (var exceptionToExamine in exceptionStack)
+            {
+                // Build the message
+                messageBuilder.AppendFormat("{0}: {1} | ", exceptionToExamine.GetType().Name, exceptionToExamine.Message);
+
+                // Get the stack trace for the exception
+                var stackTrace = new StackTrace(exceptionToExamine);
+                var stackFramesInTrace = stackTrace.GetFrames();
+                if (stackFramesInTrace != null)
+                {
+                    var reversedFrames = stackFramesInTrace.Reverse();
+                    stackFrames.AddRange(reversedFrames);
+                }
+            }
+
+            // Clean up the message
+            var message = messageBuilder
+                .ToString()
+                .Trim()
+                .TrimEnd('|')
+                .Trim();
+
+            // Convert the stack trace
+            var airbrakeStackTrace = GetTraceLines(stackFrames);
+
+            return new Backtrace
+                {
+                    CatchingMethod = airbrakeStackTrace.CatchingMethod,
+                    Message = message,
+                    Trace = airbrakeStackTrace.TraceLines
+                };
+        }
+        private class TraceLineResult
+        {
+            public List<AirbrakeTraceLine> TraceLines { get; set; }
+
+            public MethodBase CatchingMethod { get; set; }
+        }
+
+        private TraceLineResult GetTraceLines(IEnumerable<StackFrame> stackFrames)
+        {
+            var lines = new List<AirbrakeTraceLine>();
+
+            MethodBase method;
+            MethodBase catchingMethod = null;
+
+            foreach (StackFrame frame in stackFrames)
+            {
+                method = frame.GetMethod();
+
+                if(catchingMethod == null)
+                    catchingMethod = method;
+
+                int lineNumber = frame.GetFileLineNumber();
+
+                if (lineNumber == 0)
+                {
+                    _log.Debug(f => f("No line number found in {0}, using IL offset instead.", method));
+                    lineNumber = frame.GetILOffset();
+                }
+
+                string file = frame.GetFileName();
+
+                if (String.IsNullOrEmpty(file))
+                {
+                    // ReSharper disable ConditionIsAlwaysTrueOrFalse
+                    file = method.ReflectedType != null
+                               ? method.ReflectedType.FullName
+                               : "(unknown)";
+                    // ReSharper restore ConditionIsAlwaysTrueOrFalse
+                }
+
+                var line = new AirbrakeTraceLine(file, lineNumber)
+                {
+                    Method = method.Name
+                };
+
+                lines.Add(line);
+            }
+
+            if(!lines.Any())
+            {
+                lines.Add(new AirbrakeTraceLine("none", 0));
+            }
+
+            if (catchingMethod == null)
+                catchingMethod = GetCatchingMethod();
+
+            return new TraceLineResult { CatchingMethod = catchingMethod, TraceLines = lines };
+        }
+
+        private Queue<Exception> GetExceptionStack(Exception exception)
+        {
+            var exceptionQueue = new Queue<Exception>();
+
+            var exceptionToExamine = exception;
+
+            do
+            {
+                exceptionQueue.Enqueue(exceptionToExamine);
+                exceptionToExamine = exceptionToExamine.InnerException;
+
+            } while (exceptionToExamine != null);
+
+            return exceptionQueue;
+        }
+
+        private MethodBase GetCatchingMethod()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+
+            if (assembly.EntryPoint == null)
+                assembly = Assembly.GetCallingAssembly();
+
+            if (assembly.EntryPoint == null)
+                assembly = Assembly.GetEntryAssembly();
+
+            MethodBase catchingMethod = assembly == null
+                                            ? null
+                                            : assembly.EntryPoint;
+
+            return catchingMethod;
+        }
+    }
+}

--- a/src/app/SharpBrake/IBuilder.cs
+++ b/src/app/SharpBrake/IBuilder.cs
@@ -1,0 +1,17 @@
+namespace SharpBrake
+{
+    /// <summary>
+    /// Builder interface
+    /// </summary>
+    /// <typeparam name="TIn">Input to build from</typeparam>
+    /// <typeparam name="TOut">Type being built</typeparam>
+    public interface IBuilder<in TIn, out TOut>
+    {
+        /// <summary>
+        /// Build an instance of TOut from TIn
+        /// </summary>
+        /// <param name="input">Input to build from</param>
+        /// <returns></returns>
+        TOut Build(TIn input);
+    }
+}

--- a/src/app/SharpBrake/SharpBrake.2010.csproj
+++ b/src/app/SharpBrake/SharpBrake.2010.csproj
@@ -56,7 +56,10 @@
     <Compile Include="AirbrakeConfiguration.cs" />
     <Compile Include="AirbrakeNoticeBuilder.cs" />
     <Compile Include="AirbrakeResponse.cs" />
+    <Compile Include="Backtrace.cs" />
+    <Compile Include="BacktraceBuilder.cs" />
     <Compile Include="Extensions.cs" />
+    <Compile Include="IBuilder.cs" />
     <Compile Include="RequestEndEventArgs.cs" />
     <Compile Include="RequestEndEventHandler.cs" />
     <Compile Include="NotifierHttpModule.cs" />

--- a/src/tests/Tests/AirbrakeClientTests.cs
+++ b/src/tests/Tests/AirbrakeClientTests.cs
@@ -1,5 +1,5 @@
 using System;
-
+using Common.Logging;
 using NUnit.Framework;
 
 using SharpBrake.Serialization;
@@ -42,7 +42,7 @@ namespace SharpBrake.Tests
                 EnvironmentName = "test",
             };
 
-            var builder = new AirbrakeNoticeBuilder(configuration);
+            var builder = new AirbrakeNoticeBuilder(configuration, new BacktraceBuilder(LogManager.GetLogger<BacktraceBuilder>()));
 
             AirbrakeNotice notice = builder.Notice(new Exception("Test"));
 

--- a/src/tests/Tests/BacktraceBuilderTests.cs
+++ b/src/tests/Tests/BacktraceBuilderTests.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Common.Logging;
+using NUnit.Framework;
+
+namespace SharpBrake.Tests
+{
+    [TestFixture]
+    public class BacktraceBuilderTests
+    {
+        [Test]
+        public void When_building_a_backtrace_then_the_message_contains_messages_from_the_topmost_exception_and_all_inner_exceptions()
+        {
+            // Arrange
+            var log = new Moq.Mock<ILog>();
+
+            var exception = GetException();
+
+            var builder = new BacktraceBuilder(log.Object);
+
+            // Act
+            var response = builder.Build(exception);
+
+            // Assert
+            Assert.That(response.Message, Is.EqualTo("Exception: last thing wrong | ApplicationException: level two message | DivideByZeroException: Attempted to divide by zero."));
+        }
+
+        [Test]
+        public void When_building_a_backtrace_then_the_trace_contains_the_full_stack_trace()
+        {
+            // Arrange
+            var log = new Moq.Mock<ILog>();
+
+            var exception = GetException();
+
+            var builder = new BacktraceBuilder(log.Object);
+
+            // Act
+            var response = builder.Build(exception);
+
+            // Assert
+            Assert.That(response.Trace, Has.Count.EqualTo(5));
+            Assert.That(response.Trace[0].Method, Is.EqualTo("GetException"));
+        }
+
+        [Test]
+        public void When_building_a_backtrace_then_the_catching_method_is_set()
+        {
+            // Arrange
+            var log = new Moq.Mock<ILog>();
+
+            var exception = GetException();
+
+            var builder = new BacktraceBuilder(log.Object);
+
+            // Act
+            var response = builder.Build(exception);
+
+            // Assert
+            Assert.That(response.CatchingMethod, Is.Not.Null);
+        } 
+
+        private Exception GetException()
+        {
+            try
+            {
+                InnerException1();
+
+                return null;
+            }
+            catch (Exception exception)
+            {
+                return exception;
+            }
+
+        }
+
+        private static void InnerException1()
+        {
+            try
+            {
+                InnerException2();
+            }
+            catch (Exception secondException)
+            {
+                var thirdException = new Exception("last thing wrong", secondException);
+                throw thirdException;
+            }
+        }
+
+        private static void InnerException2()
+        {
+            try
+            {
+                var one = 1;
+                var zero = 0;
+
+                var result = one/zero;
+            }
+            catch (Exception firstException)
+            {
+                var wrappedException = new ApplicationException("level two message", firstException);
+                throw wrappedException;
+            }
+        }
+    }
+}

--- a/src/tests/Tests/BacktraceBuilderTests.cs
+++ b/src/tests/Tests/BacktraceBuilderTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using Common.Logging;
 using NUnit.Framework;
 
@@ -15,7 +13,7 @@ namespace SharpBrake.Tests
             // Arrange
             var log = new Moq.Mock<ILog>();
 
-            var exception = GetException();
+            var exception = GetDeepException();
 
             var builder = new BacktraceBuilder(log.Object);
 
@@ -32,7 +30,7 @@ namespace SharpBrake.Tests
             // Arrange
             var log = new Moq.Mock<ILog>();
 
-            var exception = GetException();
+            var exception = GetDeepException();
 
             var builder = new BacktraceBuilder(log.Object);
 
@@ -50,7 +48,7 @@ namespace SharpBrake.Tests
             // Arrange
             var log = new Moq.Mock<ILog>();
 
-            var exception = GetException();
+            var exception = GetDeepException();
 
             var builder = new BacktraceBuilder(log.Object);
 
@@ -61,7 +59,7 @@ namespace SharpBrake.Tests
             Assert.That(response.CatchingMethod, Is.Not.Null);
         } 
 
-        private Exception GetException()
+        private Exception GetDeepException()
         {
             try
             {

--- a/src/tests/Tests/NoticeComponentsCreation.cs
+++ b/src/tests/Tests/NoticeComponentsCreation.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 using System.Linq.Expressions;
-
+using Common.Logging;
 using NUnit.Framework;
 
 using SharpBrake.Serialization;
@@ -23,7 +23,7 @@ namespace SharpBrake.Tests
                 ApiKey = "123456",
                 EnvironmentName = "test"
             };
-            this.builder = new AirbrakeNoticeBuilder(this.config);
+            this.builder = new AirbrakeNoticeBuilder(this.config,new BacktraceBuilder(LogManager.GetLogger<BacktraceBuilder>()));
         }
 
         #endregion

--- a/src/tests/Tests/Tests.2010.csproj
+++ b/src/tests/Tests/Tests.2010.csproj
@@ -50,8 +50,12 @@
     <Reference Include="log4net">
       <HintPath>..\..\packages\log4net.1.2.10\lib\2.0\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.2.6.0.12054\lib\nunit.framework.dll</HintPath>
+    <Reference Include="Moq">
+      <HintPath>..\..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.1.12217, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\NUnit.2.6.1\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
@@ -61,6 +65,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BacktraceBuilderTests.cs" />
     <Compile Include="SchemaValidation.cs" />
     <Compile Include="AirbrakeClientTests.cs" />
     <Compile Include="AirbrakeValidator.cs" />

--- a/src/tests/Tests/packages.config
+++ b/src/tests/Tests/packages.config
@@ -4,5 +4,6 @@
   <package id="Common.Logging.Log4Net" version="2.0.1" />
   <package id="HttpSimulator" version="1.0.0.0" />
   <package id="log4net" version="1.2.10" />
-  <package id="NUnit" version="2.6.0.12054" />
+  <package id="Moq" version="4.0.10827" targetFramework="net40" />
+  <package id="NUnit" version="2.6.1" targetFramework="net40" />
 </packages>

--- a/src/tests/WebFormsApp/WebFormsApp.2010.csproj
+++ b/src/tests/WebFormsApp/WebFormsApp.2010.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -14,8 +15,9 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <UpgradeBackupLocation />
+    <OldToolsVersion>4.0</OldToolsVersion>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
     <UseIISExpress>false</UseIISExpress>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\SharpBrake\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -79,8 +81,13 @@
   <ItemGroup>
     <Content Include="packages.config" />
   </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
I updated SharpBrake to include inner exceptions so that a full stack trace can be built when building the AirbrakeTraceLine collection.  The AirbrakeNotice message also should contain all the messages from the full exception stack.

I also updated the solution / projects so they open in both Visual Studio 2010 and 2012.