### PR TITLE
HttpModule - log the InnerException of HttpUnhandledException wrappers

### DIFF
--- a/src/app/SharpBrake/NotifierHttpModule.cs
+++ b/src/app/SharpBrake/NotifierHttpModule.cs
@@ -40,8 +40,12 @@ namespace SharpBrake
 
             Exception exception = application.Server.GetLastError();
 
-            if (!(exception is HttpException) || ((HttpException)exception).GetHttpCode() != 404)
+            if (!(exception is HttpException) || ((HttpException)exception).GetHttpCode() != 404) {
+                if ((exception is HttpUnhandledException) && (exception.InnerException != null)) {
+                    exception = exception.InnerException;
+                }
                 exception.SendToAirbrake();
+            }
         }
     }
 }


### PR DESCRIPTION
Hi, the interesting part of an HttpUnhandledException is the InnerException it contains, certainly from a logging point of view. My only nagging doubt is would we want to tag it in some way to indicate it wasn't caught by any existing exception handler?