### PR TITLE
IIS7 Integrated Mode Compatibility Update

### DIFF
--- a/src/app/SharpBrake/AirbrakeConfiguration.cs
+++ b/src/app/SharpBrake/AirbrakeConfiguration.cs
@@ -20,9 +20,7 @@ namespace SharpBrake
             ServerUri = ConfigurationManager.AppSettings["Airbrake.ServerUri"]
                         ?? "https://api.airbrake.io/notifier_api/v2/notices";
 
-            ProjectRoot = HttpContext.Current != null
-                              ? HttpContext.Current.Request.ApplicationPath
-                              : Environment.CurrentDirectory;
+            ProjectRoot = HttpRuntime.AppDomainAppVirtualPath ?? Environment.CurrentDirectory;
 
             string[] values = ConfigurationManager.AppSettings.GetValues("Airbrake.AppVersion");
             


### PR DESCRIPTION
Request context is unavailable during the Application_Start event of IIS7 integrated applications. The error "HttpException (0x80004005): Request is not available in this context" will occur. To resolve the issue, we can get the root path by using "HttpRuntime.AppDomainAppVirtualPath" instead. 
