### PR TITLE
Fix always falling back to IL offsets instead of using line numbers

### DIFF
--- a/src/app/SharpBrake/AirbrakeNoticeBuilder.cs
+++ b/src/app/SharpBrake/AirbrakeNoticeBuilder.cs
@@ -251,7 +251,7 @@ namespace SharpBrake
                                  : assembly.EntryPoint;
 
             List<AirbrakeTraceLine> lines = new List<AirbrakeTraceLine>();
-            var stackTrace = new StackTrace(exception);
+            var stackTrace = new StackTrace(exception, true);
             StackFrame[] frames = stackTrace.GetFrames();
 
             if (frames == null || frames.Length == 0)


### PR DESCRIPTION
If `fNeedFileInfo` is not set to true when constructing a `StackTrace` (see http://msdn.microsoft.com/en-us/library/dsay49kt(v=vs.110).aspx), then the file names, line numbers, and column numbers will not be captured. As a result, SharpBrake always falls back to using IL offsets instead.

This is illustrated by the following code snippet:

``` csharp
using System;
using System.Diagnostics;

namespace ConsoleApplication1
{
    class Program
    {
        static void Throw()
        {
            throw new Exception("TestError");
        }

        static void PrintStackTrace(StackTrace stackTrace)
        {
            foreach (var frame in stackTrace.GetFrames())
            {
                Console.Write(frame);
            }
        }

        static void Main(string[] args)
        {
            try
            {
                Throw();
            }
            catch (Exception e)
            {
                PrintStackTrace(new StackTrace(e));
                Console.WriteLine("--------------------------------");
                PrintStackTrace(new StackTrace(e, true));
            }
        }
    }
}
```

Output:

```
Throw at offset 78 in file:line:column <filename unknown>:0:0
Main at offset 53 in file:line:column <filename unknown>:0:0
--------------------------------
Throw at offset 78 in file:line:column c:\Users\Jeff\Desktop\SharpBrake\src\ConsoleApplication1\Program.cs:10:4
Main at offset 53 in file:line:column c:\Users\Jeff\Desktop\SharpBrake\src\ConsoleApplication1\Program.cs:25:5
```
