### PR TITLE
Allow passing in custom key value pairs to send to airbrake

### DIFF
--- a/src/app/SharpBrake/AirbrakeClient.cs
+++ b/src/app/SharpBrake/AirbrakeClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
 using System.Net;
@@ -54,9 +55,10 @@ namespace SharpBrake
         /// Sends the specified exception to Airbrake.
         /// </summary>
         /// <param name="exception">The e.</param>
-        public void Send(Exception exception)
+        /// <param name="info"> Additional info to send to Airbrake.</param>
+        public void Send(Exception exception, Dictionary<string, string> info = null)
         {
-            AirbrakeNotice notice = this.builder.Notice(exception);
+            AirbrakeNotice notice = this.builder.Notice(exception, info);
 
             //TODO: set up request, session and server headers
             // Why would that be necessary, it's set in Send(AirbrakeNotice), isn't it? - @asbjornu

--- a/src/app/SharpBrake/Extensions.cs
+++ b/src/app/SharpBrake/Extensions.cs
@@ -15,10 +15,11 @@ namespace SharpBrake
         /// Sends the <paramref name="exception"/> to Airbrake.
         /// </summary>
         /// <param name="exception">The exception to send to Airbrake.</param>
-        public static void SendToAirbrake(this Exception exception)
+        /// <param name="info"> Additional info to send to Airbrake.</param>
+        public static void SendToAirbrake(this Exception exception, Dictionary<string, string> info = null)
         {
             var client = new AirbrakeClient();
-            client.Send(exception);
+            client.Send(exception, info);
         }
 
 


### PR DESCRIPTION
Allow user to pass custom info to airbrake via a Dictionary of additional info:
 * Any key prefixed with "Environment" is added to the Environment section of airbrake
 * Any key prefixed with "Session" is added to the Session section of airbrake
 * Everything else is added to params