### PR TITLE
Add option to set custom key/value params to be sent with notices

### DIFF
--- a/src/app/SharpBrake/AirbrakeConfiguration.cs
+++ b/src/app/SharpBrake/AirbrakeConfiguration.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
 using System.Web;
+using SharpBrake.Serialization;
 
 namespace SharpBrake
 {
@@ -69,5 +71,11 @@ namespace SharpBrake
         /// The project root.
         /// </value>
         public string ProjectRoot { get; set; }
+
+        /// <summary>
+        /// Gets or sets custom parameters.
+        /// </summary>
+        /// <value>Custom parameters.</value>
+        public List<AirbrakeVar> Params { get; set; }
     }
 }

--- a/src/app/SharpBrake/AirbrakeNoticeBuilder.cs
+++ b/src/app/SharpBrake/AirbrakeNoticeBuilder.cs
@@ -131,6 +131,7 @@ namespace SharpBrake
                 Error = error,
                 Notifier = Notifier,
                 ServerEnvironment = ServerEnvironment,
+                Params = Configuration.Params
             };
 
             MethodBase catchingMethod = (error != null)
@@ -198,6 +199,11 @@ namespace SharpBrake
             var parameters = new List<AirbrakeVar>();
             var session = new List<AirbrakeVar>();
             var httpContext = HttpContext.Current;
+
+            if (notice.Params != null)
+            {
+                parameters.AddRange(notice.Params);
+            }
 
             if (httpContext != null)
             {

--- a/src/app/SharpBrake/Serialization/AirbrakeNotice.cs
+++ b/src/app/SharpBrake/Serialization/AirbrakeNotice.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Serialization;
+﻿using System.Collections.Generic;
+using System.Xml.Serialization;
 
 namespace SharpBrake.Serialization
 {
@@ -71,5 +72,14 @@ namespace SharpBrake.Serialization
         /// </value>
         [XmlAttribute("version")]
         public string Version { get; set; }
+
+        /// <summary>
+        /// Gets or sets custom parameters.
+        /// </summary>
+        /// <value>
+        /// Custom parameters.
+        /// </value>
+        [XmlElement("params")]
+        public List<AirbrakeVar> Params { get; set; }
     }
 }


### PR DESCRIPTION
This adds the ability to send arbitrary key/value parameters with Airbrake notices, as supported by the Airbrake API here: https://airbrake.io/docs/api/#create-notice-v3