### PR TITLE
Correct config option name

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ assumed) and the scheme ("https" will be assumed).
 
 ```csharp
 var config = new AirbrakeConfig {
-    AppVersion = "http://127.0.0.1:8000"
+    Host = "http://127.0.0.1:8000"
 };
 ```
 


### PR DESCRIPTION
Use "Host" instead of "AppVersion" in the [host section](https://github.com/airbrake/SharpBrake#host) of the config options

### Before
![screen shot 2017-03-22 at 5 01 44 pm](https://cloud.githubusercontent.com/assets/2172513/24226058/7e962a2a-0f21-11e7-8a49-e3914e168d4f.png)

### After
![screen shot 2017-03-22 at 5 04 32 pm](https://cloud.githubusercontent.com/assets/2172513/24226077/a3d9b248-0f21-11e7-977b-b158e2da3f19.png)
