### PR TITLE
Improve support for error location (action and component fields)

### DIFF
--- a/src/Sharpbrake.Client/IHttpContext.cs
+++ b/src/Sharpbrake.Client/IHttpContext.cs
@@ -46,5 +46,15 @@ namespace Sharpbrake.Client
         /// User's name.
         /// </summary>
         string UserName { get; set; }
+
+        /// <summary>
+        /// The action in which the error occurred.
+        /// </summary>
+        string Action { get; set; }
+
+        /// <summary>
+        /// The component in which the error occurred.
+        /// </summary>
+        string Component { get; set; }
     }
 }

--- a/src/Sharpbrake.Client/NoticeBuilder.cs
+++ b/src/Sharpbrake.Client/NoticeBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Sharpbrake.Client.Model;
 
@@ -51,6 +52,17 @@ namespace Sharpbrake.Client
             }
 
             notice.Errors = errors;
+
+            var error = errors.FirstOrDefault();
+            if (error != null && error.Backtrace != null)
+            {
+                var backtrace = error.Backtrace.FirstOrDefault();
+                if (backtrace != null)
+                {
+                    notice.Context.Action = backtrace.Function;
+                    notice.Context.Component = backtrace.File;
+                }
+            }
         }
 
         /// <summary>
@@ -90,6 +102,12 @@ namespace Sharpbrake.Client
 
             notice.Context.Url = httpContext.Url;
             notice.Context.UserAgent = httpContext.UserAgent;
+
+            if (httpContext.Action != null && httpContext.Component != null)
+            {
+                notice.Context.Action = httpContext.Action;
+                notice.Context.Component = httpContext.Component;
+            }
 
             notice.Context.User = new UserInfo
             {

--- a/src/Sharpbrake.Http.Middleware/AspNetCoreHttpContext.cs
+++ b/src/Sharpbrake.Http.Middleware/AspNetCoreHttpContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Primitives;
 using Sharpbrake.Client;
 
@@ -23,6 +24,9 @@ namespace Sharpbrake.Http.Middleware
         public string UserId { get; set; }
         public string UserEmail { get; set; }
         public string UserName { get; set; }
+
+        public string Action { get; set; }
+        public string Component { get; set; }
 
         public AspNetCoreHttpContext(HttpContext context)
         {
@@ -65,6 +69,18 @@ namespace Sharpbrake.Http.Middleware
 
             UserName = context.User.Identity.Name;
             Url = context.Request.Path.ToUriComponent();
+
+            var routingFeature = context.Features[typeof(IRoutingFeature)] as IRoutingFeature;
+            if (routingFeature != null)
+            {
+                var routeData = routingFeature.RouteData;
+
+                if (routeData.Values.ContainsKey("action"))
+                    Action = routeData.Values["action"].ToString();
+
+                if (routeData.Values.ContainsKey("controller"))
+                    Component = routeData.Values["controller"].ToString();
+            }
         }
 
         private static T TryGet<T>(Func<T> getter) where T : class

--- a/src/Sharpbrake.Http.Middleware/project.json
+++ b/src/Sharpbrake.Http.Middleware/project.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "Sharpbrake.Client": "3.0.2",
     "Microsoft.AspNetCore.Http.Abstractions": "1.0.0",
+    "Microsoft.AspNetCore.Routing": "1.0.0",
     "Microsoft.Extensions.Configuration": "1.0.0",
     "Microsoft.Extensions.Configuration.Json": "1.0.0"
   },

--- a/src/Sharpbrake.Http.Module/AspNetHttpContext.cs
+++ b/src/Sharpbrake.Http.Module/AspNetHttpContext.cs
@@ -21,6 +21,9 @@ namespace Sharpbrake.Http.Module
         public string UserEmail { get; set; }
         public string UserName { get; set; }
 
+        public string Action { get; set; }
+        public string Component { get; set; }
+
         public AspNetHttpContext(HttpContext context)
         {
             var request = context.Request;
@@ -53,6 +56,16 @@ namespace Sharpbrake.Http.Module
                 Session = context.Session.Keys.Cast<string>()
                     .ToDictionary(key => key, key => context.Session[key].ToString());
             }
+
+#if !NET35
+            var routeData = request.RequestContext.RouteData;
+
+            if (routeData.Values.ContainsKey("action"))
+                Action = routeData.Values["action"].ToString();
+
+            if (routeData.Values.ContainsKey("controller"))
+                Component = routeData.Values["controller"].ToString();
+#endif
         }
     }
 }

--- a/test/Sharpbrake.Client.Tests/Mocks/FakeHttpContext.cs
+++ b/test/Sharpbrake.Client.Tests/Mocks/FakeHttpContext.cs
@@ -15,5 +15,7 @@ namespace Sharpbrake.Client.Tests.Mocks
         public string UserId { get; set; }
         public string UserEmail { get; set; }
         public string UserName { get; set; }
+        public string Action { get; set; }
+        public string Component { get; set; }
     }
 }

--- a/test/Sharpbrake.Client.Tests/NoticeBuilderTests.cs
+++ b/test/Sharpbrake.Client.Tests/NoticeBuilderTests.cs
@@ -104,6 +104,18 @@ namespace Sharpbrake.Client.Tests
         }
 
         [Fact]
+        public void SetErrorEntries_ShouldNotSetActionAndComponentIfNoError()
+        {
+            var builder = new NoticeBuilder();
+            builder.SetErrorEntries(null);
+
+            var notice = builder.ToNotice();
+
+            Assert.True(string.IsNullOrEmpty(notice.Context.Action));
+            Assert.True(string.IsNullOrEmpty(notice.Context.Component));
+        }
+
+        [Fact]
         public void SetConfigurationContext_ShouldSetEnvironmentNameAndAppVersion()
         {
             var builder = new NoticeBuilder();
@@ -269,6 +281,24 @@ namespace Sharpbrake.Client.Tests
             var notice = builder.ToNotice();
 
             Assert.NotNull(notice.HttpContext);
+        }
+
+        [Fact]
+        public void SetHttpContext_ShouldSetActionAndContextIfProvided()
+        {
+            var httpContext = new FakeHttpContext
+            {
+                Action = "Action",
+                Component = "Component"
+            };
+
+            var builder = new NoticeBuilder();
+            builder.SetHttpContext(httpContext, null);
+
+            var notice = builder.ToNotice();
+
+            Assert.True(!string.IsNullOrEmpty(notice.Context.Action));
+            Assert.True(!string.IsNullOrEmpty(notice.Context.Component));
         }
 
         [Fact]


### PR DESCRIPTION
Value for *action* defaults to the method where the exception happens and for *component* to the file path. In the case of the HTTP module and middleware controller name becomes the *component* and *action* is the request action name.