### PR TITLE
Fix ignored severity in Notify method for .NET 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,8 +435,8 @@ airbrake.AddFilter(notice =>
 #### Setting severity
 
 [Severity][what-is-severity] allows categorizing how severe an error is. By
-default, it's set to `error`. To redefine severity, simply set the `Severity`
-option of an `HttpContext` object. For example:
+default, it's set to `error`. To redefine severity, simply pass the `Severity`
+as a parameter to the `NotifyAsync` (or `Notify`) method. For example:
 
 ```csharp
 airbrake.NotifyAsync(ex, null,

--- a/src/Sharpbrake.Client/AirbrakeNotifier.cs
+++ b/src/Sharpbrake.Client/AirbrakeNotifier.cs
@@ -84,7 +84,7 @@ namespace Sharpbrake.Client
                 };
             }
 
-            NotifyAsync(exception, context);
+            NotifyAsync(exception, context, severity);
 #else
             var notifyTask = NotifyAsync(exception, context, severity);
             if (logger != null)


### PR DESCRIPTION
When using `Notify` method from .NET 3.5 the resulting severity is always default one. This PR should fix that. I am going also to release a new version to target that issue (v3.1.1).