### PR TITLE
Update NuGet push stage

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -239,7 +239,14 @@ Task("Publish-NuGet")
         if (package.FullPath.EndsWith("symbols.nupkg", StringComparison.OrdinalIgnoreCase))
             continue;
 
-        NuGetPush(package.FullPath, settings);
+        try
+        {
+            NuGetPush(package.FullPath, settings);
+        }
+        catch (Exception ex)
+        {
+            Information("Error: " + ex.Message);
+        }
     }
 })
 .OnError(exception =>


### PR DESCRIPTION
Add try-catch block to the NuGet push stage so failure with one package doesn't block deployment of all others.

We need that functionality to recover from the state when only one package was successfully deployed. It was caused by the issue with a certificate on NuGet symbol server (https://github.com/NuGet/Home/issues/6082).